### PR TITLE
Link to CoinUtils.lib only; remove direct MKL linkage in Cgl build #23

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ else
 fi
 
 if [[ "${target_platform}" == win-* ]]; then
-  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/mkl_rt.lib ${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
+  COINUTILS_LIB=( --with-coinutils-lib='${LIBRARY_PREFIX}/lib/libCoinUtils.lib' )
   COINUTILS_INC=( --with-coinutils-incdir='${LIBRARY_PREFIX_COIN}' )
   OSI_LIB=( --with-osi-lib='${LIBRARY_PREFIX}/lib/libOsi.lib' )
   OSI_INC=( --with-osi-incdir='${LIBRARY_PREFIX_COIN}' )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,6 @@ requirements:
     - coin-or-utils
     - coin-or-osi
     - coin-or-clp
-    - blas-devel
-    - libblas  # [unix]
-    - libcblas
-    - liblapack
-    - liblapacke  # [unix]
-    - mkl-devel  # [win]
     - zlib
     - bzip2
   run_constrained:


### PR DESCRIPTION
CoinUtils is already linked against MKL during its own build process.
Cgl itself does not make direct BLAS/LAPACK or MKL calls.
Therefore, explicitly passing MKL libraries during Cgl's build is unnecessary and may lead to unresolved symbols or linking conflicts.